### PR TITLE
Revamp the home screen for additional data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,8 @@ dependencies {
 
     implementation("com.google.zxing:core:3.5.0")
 
+    implementation("io.coil-kt:coil-compose:2.2.1")
+
     val koinVersion = "3.2.1"
     implementation("io.insert-koin:koin-core:$koinVersion")
     implementation("io.insert-koin:koin-android:$koinVersion")

--- a/app/schemas/com.xinto.mauth.db.AccountDatabase/3.json
+++ b/app/schemas/com.xinto.mauth.db.AccountDatabase/3.json
@@ -1,0 +1,93 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "9c1e38cb1cec8c1fd74fa9a90eb7b79c",
+    "entities": [
+      {
+        "tableName": "accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `icon` TEXT, `secret` TEXT NOT NULL, `label` TEXT NOT NULL, `issuer` TEXT NOT NULL, `algorithm` INTEGER NOT NULL DEFAULT 0, `type` INTEGER NOT NULL DEFAULT 0, `digits` INTEGER NOT NULL DEFAULT 6, `counter` INTEGER NOT NULL DEFAULT 0, `period` INTEGER NOT NULL DEFAULT 30, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "secret",
+            "columnName": "secret",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "issuer",
+            "columnName": "issuer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "algorithm",
+            "columnName": "algorithm",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "digits",
+            "columnName": "digits",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "6"
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "30"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9c1e38cb1cec8c1fd74fa9a90eb7b79c')"
+    ]
+  }
+}

--- a/app/src/main/java/com/xinto/mauth/contracts/PickVisualMediaPersistent.kt
+++ b/app/src/main/java/com/xinto/mauth/contracts/PickVisualMediaPersistent.kt
@@ -1,0 +1,16 @@
+package com.xinto.mauth.contracts
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+
+class PickVisualMediaPersistent : ActivityResultContracts.PickVisualMedia() {
+
+    override fun createIntent(context: Context, input: PickVisualMediaRequest): Intent {
+        return super.createIntent(context, input).apply {
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
+}

--- a/app/src/main/java/com/xinto/mauth/db/AccountDatabase.kt
+++ b/app/src/main/java/com/xinto/mauth/db/AccountDatabase.kt
@@ -5,21 +5,26 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.xinto.mauth.db.converter.OtpConverter
+import com.xinto.mauth.db.converter.UriConverter
 import com.xinto.mauth.db.converter.UuidConverter
 import com.xinto.mauth.db.dao.AccountsDao
 import com.xinto.mauth.db.entity.EntityAccount
 
 @Database(
     entities = [EntityAccount::class],
-    version = 2,
+    version = 3,
     autoMigrations = [
         AutoMigration(
             from = 1,
             to = 2
-        )
+        ),
+        AutoMigration(
+            from = 2,
+            to = 3
+        ),
     ]
 )
-@TypeConverters(UuidConverter::class, OtpConverter::class)
+@TypeConverters(UuidConverter::class, OtpConverter::class, UriConverter::class)
 abstract class AccountDatabase : RoomDatabase() {
 
     abstract fun accountsDao(): AccountsDao

--- a/app/src/main/java/com/xinto/mauth/db/converter/UriConverter.kt
+++ b/app/src/main/java/com/xinto/mauth/db/converter/UriConverter.kt
@@ -1,0 +1,18 @@
+package com.xinto.mauth.db.converter
+
+import android.net.Uri
+import androidx.room.TypeConverter
+
+class UriConverter {
+
+    @TypeConverter
+    fun convertUriToString(uri: Uri): String {
+        return uri.toString()
+    }
+
+    @TypeConverter
+    fun convertStringToUri(uriString: String): Uri {
+        return Uri.parse(uriString)
+    }
+
+}

--- a/app/src/main/java/com/xinto/mauth/db/entity/EntityAccount.kt
+++ b/app/src/main/java/com/xinto/mauth/db/entity/EntityAccount.kt
@@ -1,5 +1,6 @@
 package com.xinto.mauth.db.entity
 
+import android.net.Uri
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -12,6 +13,9 @@ data class EntityAccount(
     @PrimaryKey
     @ColumnInfo(name = "id", typeAffinity = ColumnInfo.BLOB)
     val id: UUID = UUID.randomUUID(),
+
+    @ColumnInfo(name = "icon")
+    val icon: Uri?,
 
     @ColumnInfo(name = "secret")
     val secret: String,

--- a/app/src/main/java/com/xinto/mauth/di/AddAccount.kt
+++ b/app/src/main/java/com/xinto/mauth/di/AddAccount.kt
@@ -1,5 +1,6 @@
 package com.xinto.mauth.di
 
+import android.app.Application
 import com.xinto.mauth.db.dao.AccountsDao
 import com.xinto.mauth.ui.navigation.AddAccountParams
 import com.xinto.mauth.ui.viewmodel.AddAccountViewModel
@@ -8,10 +9,11 @@ import org.koin.dsl.module
 
 val addAccountModel = module {
     fun provideAddAccountViewModel(
+        application: Application,
         params: AddAccountParams,
         accountsDao: AccountsDao
     ): AddAccountViewModel {
-        return AddAccountViewModel(params, accountsDao)
+        return AddAccountViewModel(application, params, accountsDao)
     }
 
     viewModelOf(::provideAddAccountViewModel)

--- a/app/src/main/java/com/xinto/mauth/domain/model/DomainAccount.kt
+++ b/app/src/main/java/com/xinto/mauth/domain/model/DomainAccount.kt
@@ -1,11 +1,33 @@
 package com.xinto.mauth.domain.model
 
-import java.util.*
+import com.xinto.mauth.otp.OtpDigest
 
-data class DomainAccount(
-    val id: UUID,
-    val label: String,
+interface DomainAccount {
+    val id: String
     val secret: String
-) {
-    val idString = id.toString()
+    val label: String
+    val issuer: String
+    val algorithm: OtpDigest
+    val digits: Int
+
+    data class Totp(
+        override val id: String,
+        override val secret: String,
+        override val label: String,
+        override val issuer: String,
+        override val algorithm: OtpDigest,
+        override val digits: Int,
+        val period: Int
+    ) : DomainAccount
+
+    data class Hotp(
+        override val id: String,
+        override val secret: String,
+        override val label: String,
+        override val issuer: String,
+        override val algorithm: OtpDigest,
+        override val digits: Int,
+        val counter: Int
+    ) : DomainAccount
+
 }

--- a/app/src/main/java/com/xinto/mauth/domain/model/DomainAccount.kt
+++ b/app/src/main/java/com/xinto/mauth/domain/model/DomainAccount.kt
@@ -1,33 +1,43 @@
 package com.xinto.mauth.domain.model
 
+import android.net.Uri
 import com.xinto.mauth.otp.OtpDigest
 
-interface DomainAccount {
-    val id: String
-    val secret: String
-    val label: String
-    val issuer: String
-    val algorithm: OtpDigest
-    val digits: Int
+sealed class DomainAccount {
+    abstract val id: String
+    abstract val icon: Uri?
+    abstract val secret: String
+    abstract val label: String
+    abstract val issuer: String
+    abstract val algorithm: OtpDigest
+    abstract val digits: Int
+
+    val shortLabel by lazy {
+        label.filter { it.isUpperCase() }.ifEmpty {
+            label[0].uppercase()
+        }
+    }
 
     data class Totp(
         override val id: String,
+        override val icon: Uri?,
         override val secret: String,
         override val label: String,
         override val issuer: String,
         override val algorithm: OtpDigest,
         override val digits: Int,
         val period: Int
-    ) : DomainAccount
+    ) : DomainAccount()
 
     data class Hotp(
         override val id: String,
+        override val icon: Uri?,
         override val secret: String,
         override val label: String,
         override val issuer: String,
         override val algorithm: OtpDigest,
         override val digits: Int,
         val counter: Int
-    ) : DomainAccount
+    ) : DomainAccount()
 
 }

--- a/app/src/main/java/com/xinto/mauth/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/xinto/mauth/domain/repository/HomeRepository.kt
@@ -39,6 +39,7 @@ class HomeRepositoryImpl(
             OtpType.Totp -> {
                 DomainAccount.Totp(
                     id = idString,
+                    icon = icon,
                     secret = secret,
                     label = label,
                     issuer = issuer,
@@ -51,6 +52,7 @@ class HomeRepositoryImpl(
                 DomainAccount.Hotp(
                     id = idString,
                     secret = secret,
+                    icon = icon,
                     label = label,
                     issuer = issuer,
                     algorithm = algorithm,

--- a/app/src/main/java/com/xinto/mauth/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/xinto/mauth/domain/repository/HomeRepository.kt
@@ -1,7 +1,9 @@
 package com.xinto.mauth.domain.repository
 
 import com.xinto.mauth.db.dao.AccountsDao
+import com.xinto.mauth.db.entity.EntityAccount
 import com.xinto.mauth.domain.model.DomainAccount
+import com.xinto.mauth.otp.OtpType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -19,21 +21,41 @@ class HomeRepositoryImpl(
 
     override suspend fun getAccounts(): List<DomainAccount> {
         return accountsDao.getAll().map {
-            DomainAccount(
-                id = it.id,
-                label = it.label,
-                secret = it.secret
-            )
+            it.toDomain()
         }
     }
 
     override suspend fun observeAccounts(): Flow<List<DomainAccount>> {
         return accountsDao.observeAll().map { entityAccounts ->
             entityAccounts.map {
-                DomainAccount(
-                    id = it.id,
-                    label = it.label,
-                    secret = it.secret
+                it.toDomain()
+            }
+        }
+    }
+
+    private fun EntityAccount.toDomain(): DomainAccount {
+        val idString = id.toString()
+        return when (type) {
+            OtpType.Totp -> {
+                DomainAccount.Totp(
+                    id = idString,
+                    secret = secret,
+                    label = label,
+                    issuer = issuer,
+                    algorithm = algorithm,
+                    digits = digits,
+                    period = period
+                )
+            }
+            OtpType.Hotp -> {
+                DomainAccount.Hotp(
+                    id = idString,
+                    secret = secret,
+                    label = label,
+                    issuer = issuer,
+                    algorithm = algorithm,
+                    digits = digits,
+                    counter = counter
                 )
             }
         }

--- a/app/src/main/java/com/xinto/mauth/ui/component/UriImage.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/component/UriImage.kt
@@ -1,0 +1,27 @@
+package com.xinto.mauth.ui.component
+
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+
+@Composable
+fun UriImage(
+    uri: Uri,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null
+) {
+    val context = LocalContext.current
+    Image(
+        modifier = modifier,
+        painter = rememberAsyncImagePainter(
+            model = ImageRequest.Builder(context)
+                .data(uri)
+                .build()
+        ),
+        contentDescription = contentDescription
+    )
+}

--- a/app/src/main/java/com/xinto/mauth/ui/screen/AddAccount.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/screen/AddAccount.kt
@@ -1,9 +1,13 @@
 package com.xinto.mauth.ui.screen
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -18,14 +22,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.xinto.mauth.R
+import com.xinto.mauth.contracts.PickVisualMediaPersistent
 import com.xinto.mauth.otp.OtpDigest
 import com.xinto.mauth.otp.OtpType
+import com.xinto.mauth.ui.component.UriImage
 import com.xinto.mauth.ui.component.singleItem
 import com.xinto.mauth.ui.navigation.MauthNavigator
 import com.xinto.mauth.ui.viewmodel.AddAccountViewModel
@@ -37,6 +46,9 @@ fun AddAccountScreen(
     viewModel: AddAccountViewModel = getViewModel()
 ) {
     var showExitDialog by remember { mutableStateOf(false) }
+    val imageSelectLauncher = rememberLauncherForActivityResult(PickVisualMediaPersistent()) {
+        viewModel.updateImageUri(it)
+    }
     BackHandler {
         navigator.pop()
     }
@@ -83,14 +95,21 @@ fun AddAccountScreen(
                         border = BorderStroke(
                             width = 1.dp,
                             SolidColor(MaterialTheme.colorScheme.outline)
-                        )
+                        ),
+                        onClick = {
+                            imageSelectLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                        }
                     ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                modifier = Modifier.size(36.dp),
-                                imageVector = Icons.Rounded.AddAPhoto,
-                                contentDescription = null
-                            )
+                        if (viewModel.imageUri != null) {
+                            UriImage(uri = viewModel.imageUri!!)
+                        } else {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    modifier = Modifier.size(36.dp),
+                                    imageVector = Icons.Rounded.AddAPhoto,
+                                    contentDescription = null
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
@@ -38,7 +38,7 @@ fun HomeScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
+            CenterAlignedTopAppBar(
                 title = {
                     Text(stringResource(R.string.app_name))
                 }

--- a/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
@@ -4,9 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -101,9 +99,9 @@ fun HomeScreen(
                     },
                     visible = visible,
                     issuer = if (account.issuer != "") { ->
-                        Text(account.issuer)
+                        Text(account.issuer, maxLines = 1)
                     } else null,
-                    label = { Text(account.label) },
+                    label = { Text(account.label, maxLines = 1) },
                     icon = {
                         Box(
                             Modifier
@@ -149,7 +147,7 @@ fun HomeScreen(
                                 if (visible) {
                                     Text(animatedCode)
                                 } else {
-                                    Text("*".repeat(animatedCode.length))
+                                    Text("\u2022".repeat(animatedCode.length))
                                 }
                             }
                         }
@@ -265,8 +263,11 @@ private fun Account(
                 icon()
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     if (issuer != null) {
-                        ProvideTextStyle(MaterialTheme.typography.labelMedium) {
-                            issuer()
+                        val color = LocalContentColor.current.copy(alpha = 0.7f)
+                        CompositionLocalProvider(LocalContentColor provides color) {
+                            ProvideTextStyle(MaterialTheme.typography.labelMedium) {
+                                issuer()
+                            }
                         }
                     }
                     ProvideTextStyle(MaterialTheme.typography.bodyLarge) {

--- a/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
@@ -6,7 +6,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -23,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.xinto.mauth.R
 import com.xinto.mauth.domain.model.DomainAccount
 import com.xinto.mauth.ui.component.MaterialBottomSheetDialog
+import com.xinto.mauth.ui.component.UriImage
 import com.xinto.mauth.ui.navigation.AddAccountParams
 import com.xinto.mauth.ui.navigation.MauthDestination
 import com.xinto.mauth.ui.navigation.MauthNavigator
@@ -103,12 +103,11 @@ fun HomeScreen(
                     } else null,
                     label = { Text(account.label, maxLines = 1) },
                     icon = {
-                        Box(
-                            Modifier
-                                .size(48.dp)
-                                .clip(MaterialTheme.shapes.large)
-                                .background(MaterialTheme.colorScheme.onSurfaceVariant)
-                        )
+                        if (account.icon != null) {
+                            UriImage(uri = account.icon!!)
+                        } else {
+                            Text(account.shortLabel)
+                        }
                     },
                     timer = if (account is DomainAccount.Totp) { ->
                         Box(
@@ -260,7 +259,19 @@ private fun Account(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                icon()
+                Surface(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = MaterialTheme.shapes.large
+                ) {
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        ProvideTextStyle(MaterialTheme.typography.titleLarge) {
+                            icon()
+                        }
+                    }
+                }
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     if (issuer != null) {
                         val color = LocalContentColor.current.copy(alpha = 0.7f)

--- a/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
+++ b/app/src/main/java/com/xinto/mauth/ui/screen/Home.kt
@@ -79,79 +79,98 @@ fun HomeScreen(
             )
         }
     ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            items(viewModel.accounts) { account ->
-                var visible by remember { mutableStateOf(false) }
-                val code = viewModel.codes[account.secret]
-                Account(
-                    onCopyClick = {
-                        viewModel.copyCodeToClipboard(account.label, code)
-                    },
-                    onEditClick = {},
-                    onVisibleChange = {
-                        visible = !visible
-                    },
-                    visible = visible,
-                    issuer = if (account.issuer != "") { ->
-                        Text(account.issuer, maxLines = 1)
-                    } else null,
-                    label = { Text(account.label, maxLines = 1) },
-                    icon = {
-                        if (account.icon != null) {
-                            UriImage(uri = account.icon!!)
-                        } else {
-                            Text(account.shortLabel)
-                        }
-                    },
-                    timer = if (account is DomainAccount.Totp) { ->
-                        Box(
-                            modifier = Modifier.size(36.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            val timerProgress = viewModel.timerProgresses[account.secret]
-                            val timerValue = viewModel.timerValues[account.secret]
-                            if (timerProgress != null) {
-                                val animatedTimerProgress by animateFloatAsState(
-                                    targetValue = timerProgress,
-                                    animationSpec = tween(durationMillis = 500)
-                                )
-                                CircularProgressIndicator(progress = animatedTimerProgress)
+        if (viewModel.accounts.isNotEmpty()) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(viewModel.accounts) { account ->
+                    var visible by remember { mutableStateOf(false) }
+                    val code = viewModel.codes[account.secret]
+                    Account(
+                        onCopyClick = {
+                            viewModel.copyCodeToClipboard(account.label, code)
+                        },
+                        onEditClick = {},
+                        onVisibleChange = {
+                            visible = !visible
+                        },
+                        visible = visible,
+                        issuer = if (account.issuer != "") { ->
+                            Text(account.issuer, maxLines = 1)
+                        } else null,
+                        label = { Text(account.label, maxLines = 1) },
+                        icon = {
+                            if (account.icon != null) {
+                                UriImage(uri = account.icon!!)
+                            } else {
+                                Text(account.shortLabel)
                             }
-                            if (timerValue != null) {
-                                Text(timerValue.toString())
+                        },
+                        timer = if (account is DomainAccount.Totp) { ->
+                            Box(
+                                modifier = Modifier.size(36.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                val timerProgress = viewModel.timerProgresses[account.secret]
+                                val timerValue = viewModel.timerValues[account.secret]
+                                if (timerProgress != null) {
+                                    val animatedTimerProgress by animateFloatAsState(
+                                        targetValue = timerProgress,
+                                        animationSpec = tween(durationMillis = 500)
+                                    )
+                                    CircularProgressIndicator(progress = animatedTimerProgress)
+                                }
+                                if (timerValue != null) {
+                                    Text(timerValue.toString())
+                                }
                             }
-                        }
-                    } else null,
-                    code = {
-                        AnimatedContent(
-                            targetState = code,
-                            transitionSpec = {
-                                slideIntoContainer(
-                                    towards = AnimatedContentScope.SlideDirection.Up,
-                                    animationSpec = tween(500)
-                                ) + fadeIn() with
-                                    slideOutOfContainer(
+                        } else null,
+                        code = {
+                            AnimatedContent(
+                                targetState = code,
+                                transitionSpec = {
+                                    slideIntoContainer(
                                         towards = AnimatedContentScope.SlideDirection.Up,
                                         animationSpec = tween(500)
-                                    ) + fadeOut()
-                            }
-                        ) { animatedCode ->
-                            if (animatedCode != null) {
-                                if (visible) {
-                                    Text(animatedCode)
-                                } else {
-                                    Text("\u2022".repeat(animatedCode.length))
+                                    ) + fadeIn() with
+                                        slideOutOfContainer(
+                                            towards = AnimatedContentScope.SlideDirection.Up,
+                                            animationSpec = tween(500)
+                                        ) + fadeOut()
+                                }
+                            ) { animatedCode ->
+                                if (animatedCode != null) {
+                                    if (visible) {
+                                        Text(animatedCode)
+                                    } else {
+                                        Text("\u2022".repeat(animatedCode.length))
+                                    }
                                 }
                             }
                         }
-                    }
+                    )
+                }
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    modifier = Modifier.size(72.dp),
+                    imageVector = Icons.Rounded.Dashboard,
+                    contentDescription = null
                 )
+                ProvideTextStyle(MaterialTheme.typography.headlineSmall) {
+                    Text(stringResource(R.string.home_dashboard_empty))
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Mauth</string>
 
+    <string name="home_dashboard_empty">Nothing here yet</string>
     <string name="home_addaccount_title">Add an account</string>
     <string name="home_addaccount_subtitle">Scan a QR code or enter the key manually</string>
     <string name="home_addaccount_data_scanqr">Scan a QR code</string>


### PR DESCRIPTION
- Adds a timer indicator for all TOTP accounts
- Adds the issuer above the account label
- Adds icon support
- Adds a small screen for when the data is empty
- Hidden codes now appear as bullets
- Centers the top bar 