### PR TITLE
README.md add translations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Mauth is available on F-Droid and GitHub Releases page.
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="75">](https://f-droid.org/en/packages/com.xinto.mauth)
 [<img src="github/get_it_on_github.png" height="75">](https://github.com/X1nto/Mauth/releases)
 
+# Contribute
+
+For translations use https://toolate.othing.xyz/projects/mauth/
+
 # License
 ```
 Mauth is free software: you can redistribute it and/or modify


### PR DESCRIPTION
I created a translation project for Mauth on the Toolate
https://toolate.othing.xyz/projects/mauth/

This is a Weblate instance that is maintained by F-Droid translators.
Now users can easily translate the app and it's description.
If you wish I'll send an invite to you to become an admin of the translation project. This may be useful to resolve conflicts or lock translations during a refactoring.